### PR TITLE
ryuuart/art 12 implement mobile nav menu

### DIFF
--- a/web/site/src/components/Header.astro
+++ b/web/site/src/components/Header.astro
@@ -4,27 +4,36 @@ import { SITE_TITLE } from "../consts";
 
 <header class="section">
   <nav>
-    <h2><a href="/">{SITE_TITLE}</a></h2>
-    <div class="links-container">
+    <div class="mobile-only container-menu-mobile">
       <ul class="links-list">
-        <li class="desktop-only"><a href="">Art</a></li>
-        <li class="desktop-only"><a href="">Blog</a></li>
-        <li class="desktop-only"><a href="">Portfolio</a></li>
-        <li><a href="">Contact</a></li>
+        <li><a href="">Portfolio</a></li>
+        <li><a href="">Blog</a></li>
+        <li><a href="">Artwork</a></li>
       </ul>
-      <button class="menu mobile-only">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="32"
-          height="32"
-          viewBox="0 0 32 32"
-          fill="none"
-        >
-          <rect x="4" y="8" width="24" height="2" fill="black"></rect>
-          <rect x="4" y="22" width="24" height="2" fill="black"></rect>
-          <rect x="4" y="15" width="24" height="2" fill="black"></rect>
-        </svg>
-      </button>
+    </div>
+    <div class="container-actions">
+      <h2><a href="/">{SITE_TITLE}</a></h2>
+      <div class="links-container">
+        <ul class="links-list">
+          <li class="desktop-only"><a href="">Portfolio</a></li>
+          <li class="desktop-only"><a href="">Blog</a></li>
+          <li class="desktop-only"><a href="">Artwork</a></li>
+          <li><a href="">Contact</a></li>
+        </ul>
+        <button class="menu mobile-only">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="32"
+            height="32"
+            viewBox="0 0 32 32"
+            fill="none"
+          >
+            <rect x="4" y="8" width="24" height="2" fill="black"></rect>
+            <rect x="4" y="22" width="24" height="2" fill="black"></rect>
+            <rect x="4" y="15" width="24" height="2" fill="black"></rect>
+          </svg>
+        </button>
+      </div>
     </div>
   </nav>
 </header>
@@ -50,6 +59,10 @@ import { SITE_TITLE } from "../consts";
   }
 
   nav {
+    position: relative;
+  }
+
+  .container-actions {
     padding: var(--spacing-md);
 
     display: flex;
@@ -75,8 +88,38 @@ import { SITE_TITLE } from "../consts";
 
   .links-list {
     display: flex;
-    flex-flow: row nowrap;
     align-items: flex-end;
+  }
+
+  .container-actions .links-list {
+    flex-flow: row nowrap;
+  }
+
+  .container-menu-mobile .links-list {
+    flex-flow: column nowrap;
+  }
+
+  .container-menu-mobile .links-list {
+    font-size: 3rem;
+  }
+
+  .container-menu-mobile {
+    padding: var(--spacing-md);
+
+    position: absolute;
+    inset: 0;
+    top: auto;
+    bottom: 100%;
+
+    text-align: right;
+
+    /* display: none; */
+
+    background: var(--color-bg-main);
+  }
+
+  .container-menu-mobile.active {
+    display: initial;
   }
 
   .menu {

--- a/web/site/src/components/Header.astro
+++ b/web/site/src/components/Header.astro
@@ -4,7 +4,7 @@ import { SITE_TITLE } from "../consts";
 
 <header class="section">
   <nav>
-    <div class="mobile-only container-menu-mobile">
+    <div id="mobile-links-menu" class="mobile-only container-menu-mobile">
       <ul class="links-list">
         <li><a href="">Portfolio</a></li>
         <li><a href="">Blog</a></li>
@@ -20,7 +20,7 @@ import { SITE_TITLE } from "../consts";
           <li class="desktop-only"><a href="">Artwork</a></li>
           <li><a href="">Contact</a></li>
         </ul>
-        <button class="menu mobile-only">
+        <button id="mobile-button-links-menu" class="menu mobile-only">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="32"
@@ -37,6 +37,20 @@ import { SITE_TITLE } from "../consts";
     </div>
   </nav>
 </header>
+
+<script>
+  window.addEventListener("load", () => {
+    const mobileLinksMenu = document.getElementById("mobile-links-menu");
+    const mobileButtonLinksMenu = document.getElementById(
+      "mobile-button-links-menu",
+    );
+
+    mobileButtonLinksMenu?.addEventListener("click", () => {
+      mobileLinksMenu?.classList.toggle("active");
+      document.body.classList.toggle("no-scroll");
+    });
+  });
+</script>
 
 <style>
   header {
@@ -113,7 +127,7 @@ import { SITE_TITLE } from "../consts";
 
     text-align: right;
 
-    /* display: none; */
+    display: none;
 
     background: var(--color-bg-main);
   }
@@ -127,6 +141,10 @@ import { SITE_TITLE } from "../consts";
     top: var(--spacing-sm);
 
     margin-left: var(--spacing-sm);
+  }
+
+  body.no-scroll {
+    overflow: hidden;
   }
 
   /* Extremely Small Mobile Devices*/


### PR DESCRIPTION
Implement a mobile navigation menu displaying the links that would be displayed on desktop. 
The hamburger button should enable and disable this new menu, and disable 
scrolling on the page.

Currently, scrolling is disabled by CSS which doesn't account for situations where the website is zoomed in 
introducing other opportunities to scroll the website.

- feat(site): create and style mobile nav menu
- feat(site): enable button to toggle menu and scroll
