### PR TITLE
feat(repo): modify license to cc by-nc-nd 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ I use a whole mix of tech to get all this running.
 
 ## License
 
-[MIT License](./LICENSE)
+All of this work is under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) <img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/nd.svg?ref=chooser-v1"></a>


### PR DESCRIPTION
Migrated MIT License to CC BY-NC-ND 4.0. The works on this portfolio should be viewable, 
but is not intended for adaptation or derivation commercially. 

